### PR TITLE
Make the plugin version agnostic (DrakiaXYZ's approach)

### DIFF
--- a/src/CactusPie.FastSearch/CactusPie.FastSearch.csproj
+++ b/src/CactusPie.FastSearch/CactusPie.FastSearch.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Authors>CactusPie</Authors>
   </PropertyGroup>
 

--- a/src/CactusPie.FastSearch/FastSearchPlugin.cs
+++ b/src/CactusPie.FastSearch/FastSearchPlugin.cs
@@ -5,7 +5,7 @@ using JetBrains.Annotations;
 
 namespace CactusPie.FastSearch
 {
-    [BepInPlugin("com.cactuspie.fastsearch", "CactusPie.FastSearch", "1.0.0")]
+    [BepInPlugin("com.cactuspie.fastsearch", "CactusPie.FastSearch", "1.1.0")]
     public class FastSearchPlugin : BaseUnityPlugin
     {
         internal static ConfigEntry<float> SearchTimeMultiplier { get; private set; }

--- a/src/CactusPie.FastSearch/SearchInitialDelayPatch.cs
+++ b/src/CactusPie.FastSearch/SearchInitialDelayPatch.cs
@@ -1,35 +1,53 @@
 using System;
 using System.Reflection;
 using Aki.Reflection.Patching;
+using Aki.Reflection.Utils;
 using Comfort.Common;
 using EFT.InventoryLogic;
+using System.Linq;
+using HarmonyLib;
 
 namespace CactusPie.FastSearch
 {
     public class SearchInitialDelayPatch : ModulePatch
     {
-        private static readonly FieldInfo InventoryControllerField = typeof(GClass2517).GetField("gclass2417_0", BindingFlags.Instance | BindingFlags.NonPublic);
-        private static readonly FieldInfo SearchableItemField = typeof(GClass2517).GetField("gclass2338_0", BindingFlags.Instance | BindingFlags.NonPublic);
-        
+        private static Type _searchOperationClass;
+        private static FieldInfo _inventoryControllerField;
+        private static FieldInfo _searchableItemField;
+        private static FieldInfo _terminatedField;
+
         protected override MethodBase GetTargetMethod()
         {
-            MethodInfo method = typeof(GClass2517).GetMethod("method_0", BindingFlags.NonPublic | BindingFlags.Instance);
-            
-            return method;
+            _searchOperationClass = PatchConstants.EftTypes.Single(x => x.GetMethod("GetNextDiscoveryTime", BindingFlags.Static | BindingFlags.Public) != null);
+            _terminatedField = _searchOperationClass.GetField("Terminated", BindingFlags.Instance | BindingFlags.Public);
+            var searchOperationFields = _searchOperationClass.GetFields(BindingFlags.Instance | BindingFlags.NonPublic);
+            _inventoryControllerField = searchOperationFields.Single(x => x.FieldType == typeof(InventoryControllerClass));
+            _searchableItemField = searchOperationFields.Single(x => x.FieldType == typeof(SearchableItemClass));
+
+            return AccessTools.GetDeclaredMethods(_searchOperationClass).FirstOrDefault(IsTargetMethod);
+        }
+
+        private static bool IsTargetMethod(MethodInfo mi)
+        {
+            var parameters = mi.GetParameters();
+            return parameters.Length >= 2
+                && parameters[0].Name == "callback"
+                && parameters[1].Name == "isInstant"
+                && mi.ReturnType == typeof(System.Collections.IEnumerator);
         }
 
         [PatchPrefix]
-        public static void PatchPrefix(Callback callback, bool isInstant, GClass2517 __instance)
+        public static void PatchPrefix(Callback callback, bool isInstant, object __instance)
         {
             if (FastSearchPlugin.SearchInitialDelayEnabled.Value)
             {
                 return;
             }
 
-            var inventoryController = (InventoryControllerClass)InventoryControllerField.GetValue(__instance);
-            var searchableItem = (SearchableItemClass)SearchableItemField.GetValue(__instance);
+            var inventoryController = (InventoryControllerClass)_inventoryControllerField.GetValue(__instance);
+            var searchableItem = (SearchableItemClass)_searchableItemField.GetValue(__instance);
 
-            if (__instance.Terminated)
+            if ((bool)_terminatedField.GetValue(__instance))
             {
                 return;
             }

--- a/src/CactusPie.FastSearch/SearchTimePatch.cs
+++ b/src/CactusPie.FastSearch/SearchTimePatch.cs
@@ -1,16 +1,26 @@
 using System;
 using System.Reflection;
 using Aki.Reflection.Patching;
-using TarkovDateTime = GClass1252;
+using Aki.Reflection.Utils;
+using HarmonyLib;
+using System.Linq;
 
 namespace CactusPie.FastSearch
 {
     public class SearchTimePatch : ModulePatch
     {
+        private static Type _searchOperationClass;
+        private static PropertyInfo _tarkovDateTimeNow;
+
         protected override MethodBase GetTargetMethod()
         {
-            MethodInfo method = typeof(GClass2517).GetMethod("GetNextDiscoveryTime", BindingFlags.Static | BindingFlags.Public);
-            return method;
+            Type tarkovDateTime = PatchConstants.EftTypes.Single(
+                x => x.GetProperty("MoscowNow", BindingFlags.Static | BindingFlags.Public) != null && x.GetProperty("Now", BindingFlags.Static | BindingFlags.Public) != null
+            );
+            _tarkovDateTimeNow = AccessTools.Property(tarkovDateTime, "Now");
+
+            _searchOperationClass = PatchConstants.EftTypes.Single(x => x.GetMethod("GetNextDiscoveryTime", BindingFlags.Static | BindingFlags.Public) != null);
+            return _searchOperationClass.GetMethod("GetNextDiscoveryTime", BindingFlags.Static | BindingFlags.Public);
         }
 
         [PatchPostfix]
@@ -23,13 +33,13 @@ namespace CactusPie.FastSearch
 
             float searchTimeMultiplier = FastSearchPlugin.SearchTimeMultiplier.Value;
 
+            DateTime now = (DateTime)_tarkovDateTimeNow.GetValue(null);
             if (searchTimeMultiplier == 0)
             {
-                __result = TarkovDateTime.Now;
+                __result = now;
                 return;
             }
-            
-            __result = TarkovDateTime.Now.AddTicks((long)((__result - TarkovDateTime.Now).Ticks * searchTimeMultiplier));
+            __result = now.AddTicks((long)((__result - now).Ticks * searchTimeMultiplier));
         }
     }
 }


### PR DESCRIPTION
My attempt to make this plugin independent of class and member names in specific versions of the EFT client. Inspired by https://github.com/silversupreme/SPT-UseLooseLoot/pull/1.

I tested only on SPT 3.7.0 (EFT 0.13.5.26165), because I don't have enough disk space for another tarkov instance😢.